### PR TITLE
Use global fs to save wavfile correctly

### DIFF
--- a/evaluation_vc.py
+++ b/evaluation_vc.py
@@ -37,13 +37,15 @@ from hparams import vc as hp
 from train import NPYDataSource
 
 fs = 16000
-hop_length = int(fs * (hp.frame_period * 0.001))
 
 
 def test_vc_from_path(model, path, data_mean, data_std, diffvc=True):
     model.eval()
 
+    global fs
+
     fs, x = wavfile.read(path)
+    hop_length = int(fs * (hp.frame_period * 0.001))
     x = x.astype(np.float64)
     f0, timeaxis = pyworld.dio(x, fs, frame_period=hp.frame_period)
     f0 = pyworld.stonemask(x, f0, timeaxis, fs)

--- a/evaluation_vc.py
+++ b/evaluation_vc.py
@@ -36,15 +36,10 @@ from hparams import vc as hp
 
 from train import NPYDataSource
 
-fs = 16000
 
-
-def test_vc_from_path(model, path, data_mean, data_std, diffvc=True):
+def test_vc_from_path(model, x, fs, data_mean, data_std, diffvc=True):
     model.eval()
 
-    global fs
-
-    fs, x = wavfile.read(path)
     hop_length = int(fs * (hp.frame_period * 0.001))
     x = x.astype(np.float64)
     f0, timeaxis = pyworld.dio(x, fs, frame_period=hp.frame_period)
@@ -174,8 +169,9 @@ if __name__ == "__main__":
             print(dst_dir, path)
             name = splitext(basename(path))[0]
             dst_path = join(dst_dir, name + ".wav")
+            fs, x = wavfile.read(path)
             waveform, _, _ = test_vc_from_path(
-                model, path, data_mean, data_std, diffvc=diffvc)
+                model, x, fs, data_mean, data_std, diffvc=diffvc)
             wavfile.write(dst_path, fs, waveform.astype(np.int16))
 
     sys.exit(0)


### PR DESCRIPTION
Currently `test_vc_from_path` uses `fs` variable in local scope.

However, when saving wavfile, it uses global `fs` variable.
https://github.com/r9y9/gantts/blob/master/evaluation_vc.py#L177

So I propose that `test_vc_from_path` uses global `fs` variable in order to use same `fs` value when saving and synthesizing.